### PR TITLE
Fix broken QR Code

### DIFF
--- a/multifactor/templates/multifactor/TOTP/add.html
+++ b/multifactor/templates/multifactor/TOTP/add.html
@@ -29,6 +29,6 @@
 {% block head %}
 <script src="{% static 'multifactor/js/qrcode.min.js' %}" type="text/javascript"></script>
 <script type="text/javascript">
-new QRCode(document.getElementById('qr'), "{{secret_key|safe}}");
+new QRCode(document.getElementById('qr'), "{{qr}}");
 </script>
 {% endblock %}


### PR DESCRIPTION
When I went to add a TOTP device it failed in both Authy and Google Authenticator. Adding the code worked manually in 1password. The provisioning uri was present in the view code so I just passed this to the QR library instead of the secret key.