### PR TITLE
Fix 'User gesture is not detected' erorr on FIDO2 pages

### DIFF
--- a/multifactor/templates/multifactor/FIDO2/add.html
+++ b/multifactor/templates/multifactor/FIDO2/add.html
@@ -4,6 +4,7 @@
 
 {% block content %}
 <p class="has-text-centered">Follow your browser's instructions to continue.</p>
+<button type="button" class="button is-100 is-primary" onclick="authenticate()">Start</button>
 {% endblock %}
 
 {% block head %}
@@ -41,16 +42,14 @@ function authenticate() {
 		if (res["status"] =='OK')
 			window.location.href = "{% url 'multifactor:home' %}";
 		else
-			display_error("<p>"+res["message"]+"</p><p><a href='javascript:void(0)' onclick='begin_reg()'>try again</a> or <a href='{% url 'multifactor:home' %}'>Go to Multifactor Dashboard</a></p>");
+			display_error("<p>"+res["message"]+"</p><p><a href='javascript:void(0)' onclick='authenticate()'>try again</a> or <a href='{% url 'multifactor:home' %}'>Go to Multifactor Dashboard</a></p>");
 	}, function(reason) {
-		display_error("<p>"+reason+"</p><p><a href='javascript:void(0)' onclick='begin_reg()'>Try again</a> or <a href='{% url 'multifactor:home' %}'>Go to Multifactor Dashboard</a></p>");
+		display_error("<p>"+reason+"</p><p><a href='javascript:void(0)' onclick='authenticate()'>Try again</a> or <a href='{% url 'multifactor:home' %}'>Go to Multifactor Dashboard</a></p>");
 	});
 }
 
 if (location.protocol != 'https:')
 	display_error("FIDO2 only works under HTTPS");
-else
-	setTimeout(authenticate, 500);
 </script>
 {% endblock fido_scripting %}
 {% endblock %}


### PR DESCRIPTION
Fixes #22 

It seems like FIDO2 operations on Apple devices require explicit user interaction in order to operate.

With the current automatic call to `authenticate` on the FIDO2 `add` page, I immediately see a red page with the error "NotAllowedError: This request has been cancelled by the user." on the page and "User gesture is not detected. To use the WebAuthn API, call 'navigator.credentials.create' within user activated events." in the console.

There is more information on the error here: https://support.yubico.com/hc/en-us/articles/360022004600-No-reaction-when-using-WebAuthn-on-macOS-iOS-and-iPadOS

Adding a button for the user to click seems to correct the error.

I also think the `Try Again` link was calling a method that doesn't exist (`begin_reg`), so I updated it to call `authenticate`.

These changes seem to work in:

- Safari iOS 14.6 (Face ID & Lightning Yubikey)
- Safari 14.1.1 (USB Yubikey)
- Chrome 91.0.4472.101 (USB Yubikey)