### PR TITLE
default_app_config is no longer needed from Django 3.2

### DIFF
--- a/multifactor/__init__.py
+++ b/multifactor/__init__.py
@@ -1,1 +1,3 @@
-default_app_config = 'multifactor.apps.MultifactorConfig'
+import django
+if django.VERSION < (3, 2):
+  default_app_config = 'multifactor.apps.MultifactorConfig'


### PR DESCRIPTION
```default_app_config``` was changed in Django 3.2 so that it's no longer required within the __init__.py file, nor the appConfig either. From Django 4.1 it'll be removed
 
Below is the output from ``` python -Wa manage.py test``` when running against Django 3.2

```RemovedInDjango41Warning: 'multifactor' defines default_app_config = 'multifactor.apps.MultifactorConfig'. Django now detects this configuration automatically. You can remove default_app_config.```