### PR TITLE
Make the post login info message customizable plus optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Add `multifactor` to `settings.INSTALLED_APPS` and override whichever setting yo
         'FIDO_SERVER_NAME': 'Django App',    # Human-readable name for FIDO request
         'TOKEN_ISSUER_NAME': 'Django App',   # TOTP token issuing name (to be shown in authenticator)
         'U2F_APPID': 'https://example.com',  # U2F request issuer
+        
+        # Optional Keys - Only include these keys if you wish to deviate from the default actions
+        'LOGIN_MESSAGE': '<a href="{}">Manage multifactor settings</a>.',  # {OPTIONAL} When set overloads the default post-login message.
+        'SHOW_LOGIN_MESSAGE': False,  # {OPTIONAL} <bool> Set to False to not create a post-login message
     }
 
 Ensure that [`django.contrib.messages`](https://docs.djangoproject.com/en/2.2/ref/contrib/messages/) is installed.

--- a/multifactor/__init__.py
+++ b/multifactor/__init__.py
@@ -1,1 +1,3 @@
-default_app_config = 'multifactor.apps.MultifactorConfig'
+import django
+if django.VERSION < (3, 2):
+  default_app_config = 'multifactor.apps.MultifactorConfig'

--- a/multifactor/admin.py
+++ b/multifactor/admin.py
@@ -33,12 +33,7 @@ class MultifactorUserAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         keys = UserKey.objects.filter(user=OuterRef('pk'), enabled=True)
-        return (
-            self.model.objects.filter(is_staff=True)
-            .annotate(
-                has_multifactors=Exists(keys),
-            )
-        )
+        return super().get_queryset(request).annotate(has_multifactors=Exists(keys))
 
     def get_list_display(self, request):
         if not self.multifactor_list_display:

--- a/multifactor/app_settings.py
+++ b/multifactor/app_settings.py
@@ -2,6 +2,8 @@ from django.conf import settings
 
 mf_settings = getattr(settings, 'MULTIFACTOR', {})
 
+mf_settings['LOGIN_MESSAGE'] = mf_settings.get('LOGIN_MESSAGE', 'You are now multifactor-authenticated. <a href="{}">Multifactor settings</a>.')
+mf_settings['SHOW_LOGIN_MESSAGE'] = mf_settings.get('SHOW_LOGIN_MESSAGE', True)
 mf_settings['LOGIN_CALLBACK'] = mf_settings.get('LOGIN_CALLBACK', False)
 mf_settings['RECHECK'] = mf_settings.get('RECHECK', True)
 mf_settings['RECHECK_MIN'] = mf_settings.get('RECHECK_MIN', 60 * 60 * 3)

--- a/multifactor/common.py
+++ b/multifactor/common.py
@@ -69,10 +69,8 @@ def write_session(request, key):
 
 
 def login(request):
-    messages.info(request, format_html(
-        'You are now multifactor-authenticated. <a href="{}">Multifactor settings</a>.',
-        reverse('multifactor:home')
-    ))
+    if mf_settings['SHOW_LOGIN_MESSAGE']:
+        messages.info(request, format_html(mf_settings['LOGIN_MESSAGE'], reverse('multifactor:home')))
 
     if 'multifactor-next' in request.session:
         return redirect(request.session['multifactor-next'])


### PR DESCRIPTION
This PR closes #26 by adding two new keys to the MULTIFACTOR settings to allow for the post login message to be customised as well as to completely remove it if desired