### PR TITLE
Fixes for MultifactorUserAdmin

### DIFF
--- a/multifactor/admin.py
+++ b/multifactor/admin.py
@@ -33,12 +33,7 @@ class MultifactorUserAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         keys = UserKey.objects.filter(user=OuterRef('pk'), enabled=True)
-        return (
-            self.model.objects.filter(is_staff=True)
-            .annotate(
-                has_multifactors=Exists(keys),
-            )
-        )
+        return super().get_queryset(request).annotate(has_multifactors=Exists(keys))
 
     def get_list_display(self, request):
         if not self.multifactor_list_display:


### PR DESCRIPTION
Fixes #28.
Corrects get_queryset so that it allows other mixins to adjust the filter by calling a super, removes the hardset ```is_staff=True``` filter that otherwises hides non-staff from the Django Admin