### PR TITLE
Updating required fido2 package from 0.8.1 to 0.9.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ django = "> 2.2, <4.1"
 pyotp = '^2.3'
 python-u2flib-server = '^5.0'
 python-jose = '^3'
-fido2 = '0.8.1'
+fido2 = '0.9.2'
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"


### PR DESCRIPTION
0.8.1 of python-fido2 was released on the 25th November 2019. since then 0.9.0, 0.9.1 and 0.9.2 have been released. This commit updates the required version to the latest release. 

**Warning:** Two out of the three releases since 0.8.1 including breaking changes as well as enhancements and bug fixes. From what I can see however none of these breaking changes will affect this project. Please refer to their change log https://github.com/Yubico/python-fido2/releases