### PR TITLE
Updating dependencies to use fido2 version 0.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ django = "> 2.2, <4.1"
 pyotp = '^2.6'
 python-u2flib-server = '^5.0'
 python-jose = '^3'
-fido2 = '0.9.2'
+fido2 = '0.9.3'
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"


### PR DESCRIPTION
fido2 version 0.9.3 was released on 9th November 2021 which includes a bug fix for Linux. Please see their change log - https://github.com/Yubico/python-fido2/blob/master/NEWS