### PR TITLE
Removing call to request.is_ajax in Django 4+

### DIFF
--- a/multifactor/decorators.py
+++ b/multifactor/decorators.py
@@ -1,3 +1,4 @@
+import django
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
@@ -40,7 +41,7 @@ def multifactor_protected(factors=0, user_filter=None, max_age=0, advertise=Fals
                 return view_func(request, *args, **kwargs)
 
             def force_authenticate():
-                if request.is_ajax():
+                if django.VERSION < (4, 0) and request.is_ajax():
                     raise PermissionDenied('Multifactor authentication required')
                 request.session['multifactor-next'] = request.get_full_path()
                 return redirect('multifactor:authenticate')


### PR DESCRIPTION
PR to fix #39 and allow the project to work with Django 4.0 as I missed it last time.

request.is_ajax() was marked for deprecation in Django 3.1 and removed fully in Django 4.