### PR TITLE
Update to show support for Django 4.2 and Python up to 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ This project officially supports Python 3.8+ and Django 3.2+.
 | 3.8               | Y       | Y      | Y       | Y       | N/A     |
 | 3.9               | Y       | Y      | Y       | Y       | N/A     |
 | 3.10              | N       | Y      | Y       | Y       | N/A     |
+| 3.11              | N       | N      | N       | Y       | Y  
+
+* Python 3.11 only works with Django 4.1.3+
 
 
 ## Installation:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,21 @@ FIDO2/WebAuthn is the big-ticket item for MFA. It allows the browser to interfac
  * **android-safetynet** (Chrome 70+)
  * **NFC devices using PCSC** (Not Tested, but as supported in fido2)
 
-This project targets modern stacks. Django 2.2+ and Python 3.5+.
-
 **Database support**: Depends on *either* PostgreSQL or Django 3.1+, or both for a sane JSONField implementation. If you're on Postgres, you can carry on using Django 2.x but SQLite3, MySQL, Oracle, etc users will need to upgrade.
 
+# Python and Django Support
+This project targets modern stacks. Django 2.2+ and Python 3.5+.
+
+This project officially supports Python 3.8+ and Django 3.2+.
+
+| **Python/Django** | **2.2** |**3.2** | **4.0** | **4.1** | **4.2** |
+|-------------------|---------|--------|---------|---------|---------|
+| 3.5               | Y       | N      | N       | N       | N/A     |
+| 3.6               | Y       | Y      | N       | N       | N/A     |
+| 3.7               | Y       | Y      | N       | N       | N/A     |
+| 3.8               | Y       | Y      | Y       | Y       | N/A     |
+| 3.9               | Y       | Y      | Y       | Y       | N/A     |
+| 3.10              | N       | Y      | Y       | Y       | N/A     |
 
 
 ## Installation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 packages = [
@@ -38,8 +39,8 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5, ^3.6 || ^3.7 || ^3.8 || ^3.9 || ^3.10"
-django = "> 2.2, <4.2"
+python = "^3.5, ^3.6 || ^3.7 || ^3.8 || ^3.9 || ^3.10 || ^3.11"
+django = "> 2.2, <5"
 pyotp = '^2.6'
 python-u2flib-server = '^5.0'
 python-jose = '^3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ django = "> 2.2, <5"
 pyotp = '^2.6'
 python-u2flib-server = '^5.0'
 python-jose = '^3'
-fido2 = '0.9.3'
+fido2 = '1.1.0'
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ django = "> 2.2, <5"
 pyotp = '^2.6'
 python-u2flib-server = '^5.0'
 python-jose = '^3'
-fido2 = '1.1.0'
+fido2 = '0.9.3'
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-multifactor"
-version = "0.5.4"
+version = "0.5.5"
 description = "Drop-in multifactor authentication subsystem for Django."
 authors = ["Oli Warner <oli@thepcspy.com>"]
 repository = "https://github.com/oliwarner/django-multifactor"
@@ -18,6 +18,7 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
+    "Framework :: Django :: 4.2",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",

--- a/testsite/requirements.txt
+++ b/testsite/requirements.txt
@@ -1,4 +1,4 @@
 pip
-Django<=4.2
+Django<=5
 django-decorator-include
 -e ../


### PR DESCRIPTION
Updating the README with a table to display the Python/Django support so that it's easier to read for users.

I would suggest that Python 3.5 and 3.6 alongside Django 2.2 be dropped as being officially supported due to them being past their EOL unless you require them yourself. Whilst the project does work with them dropping them would also allow the requirements to be updated including Fido2 to 1.0.0, #44,  though the project should also be tested for compatibility with the forthcoming 1.1.0

*UPDATE*

I've now included updating  the project to show support for Python 3.11 and Django 4.2 the latter was released today but I have completed my tests to check that everything is working