### PR TITLE
Respects BYPASS setting in mixins

### DIFF
--- a/multifactor/mixins.py
+++ b/multifactor/mixins.py
@@ -1,7 +1,7 @@
 from django.shortcuts import redirect
 
 from .models import UserKey
-from .common import active_factors
+from .common import active_factors, is_bypassed
 
 
 class MultiFactorMixin:
@@ -16,13 +16,14 @@ class MultiFactorMixin:
         self.active_factors = active_factors(request)
         self.factors = UserKey.objects.filter(user=request.user)
         self.has_multifactor = self.factors.filter(enabled=True).exists()
+        self.bypass = is_bypassed(request)
 
 
 class RequireMultiAuthMixin(MultiFactorMixin):
     """Require Multifactor, force user to add factors if none on account."""
 
     def dispatch(self, request, *args, **kwargs):
-        if not self.active_factors:
+        if not self.active_factors and not self.bypass:
             request.session['multifactor-next'] = request.get_full_path()
             if self.has_multifactor:
                 return redirect('multifactor:authenticate')
@@ -36,7 +37,7 @@ class PreferMultiAuthMixin(MultiFactorMixin):
     """Use Multifactor if user has active factors."""
 
     def dispatch(self, request, *args, **kwargs):
-        if not self.active_factors and self.has_multifactor:
+        if not self.active_factors and not self.bypass and self.has_multifactor:
             request.session['multifactor-next'] = request.get_full_path()
             return redirect('multifactor:authenticate')
 


### PR DESCRIPTION
Currently the MULTIFACTOR.BYPASS setting is only respected in the decorator code. I use class-based views, and so the decorator is not suitable, but mixins are - however, the mixins don't respect the BYPASS setting. This simple fix seems to work for my use case.