### PR TITLE
Updating documentation and pyproject.toml to show Python 3.12 and Django 5.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ FIDO2/WebAuthn is the big-ticket item for MFA. It allows the browser to interfac
 # Python and Django Support
 This project targets modern stacks, officially supporting Python 3.8+ and Django 3.2+.
 
-| **Python/Django** | **2.2** |**3.2** | **4.0** | **4.1** | **4.2** |
-|-------------------|---------|--------|---------|---------|---------|
-| 3.8               | Y       | Y      | Y       | Y       | N/A     |
-| 3.9               | Y       | Y      | Y       | Y       | N/A     |
-| 3.10              | N       | Y      | Y       | Y       | N/A     |
-| 3.11              | N       | N      | N       | Y       | Y  
+| **Python/Django** | **2.2** |**3.2** | **4.0** | **4.1** | **4.2** | **5.0** |
+|-------------------|---------|--------|---------|---------|---------|---------|
+| 3.8               | Y       | Y      | Y       | Y       | N/A     | N/A     |
+| 3.9               | Y       | Y      | Y       | Y       | N/A     | N/A     |
+| 3.10              | N       | Y      | Y       | Y       | N/A     | Y       |
+| 3.11              | N       | N      | N       | Y       | Y       | Y       |
+| 3.12              | N       | N      | N       | N       | Y       | Y       |
 
 * Python 3.11 only works with Django 4.1.3+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.7, <4.0"
-django = "> 2.2, <= 5.0"
+django = "> 2.2, <= 5.1"
 pyotp = '^2.9'
 fido2 = '1.1.2'
 

--- a/testsite/requirements.txt
+++ b/testsite/requirements.txt
@@ -1,5 +1,5 @@
 pip
-Django<=5
+Django<=5.1
 django-decorator-include
 django_extensions
 django-debug-toolbar


### PR DESCRIPTION
I've tested the project against Python 3.12 and Django 5.0.1 and I'm happy that everything is working find.

As such this PR updates the documentation and pyproject.toml file so that anyone using Django 5.0 can install and use this page

This will close issue #62 

It'll be good to add automated tests to the commits to help show support but I've not started looking at that just yet