### PR TITLE
Localhost compatibility

### DIFF
--- a/multifactor/factors/fido2.py
+++ b/multifactor/factors/fido2.py
@@ -14,6 +14,7 @@ from ..common import write_session, login
 from ..app_settings import mf_settings
 
 import json
+from urllib.parse import urlparse
 
 fido2.features.webauthn_json_mapping.enabled = True
 
@@ -82,7 +83,7 @@ def get_user_credentials(request):
         for key in UserKey.objects.filter(
             user=request.user,
             key_type=KeyTypes.FIDO2,
-            properties__domain=request.get_host(),
+            properties__domain=urlparse(request.get_host()).scheme,
             enabled=True,
         )
     ]

--- a/multifactor/views.py
+++ b/multifactor/views.py
@@ -11,6 +11,8 @@ from django.utils.module_loading import import_string
 from django.views.generic import TemplateView, UpdateView
 
 from collections import defaultdict
+from urllib.parse import urlparse
+
 
 from .models import UserKey, DisabledFallback, KeyTypes, DOMAIN_KEYS
 from .common import render, method_url, active_factors, has_multifactor, disabled_fallbacks
@@ -130,7 +132,7 @@ class Authenticate(LoginRequiredMixin, MultiFactorMixin, TemplateView):
                 domain = factor.properties.get('domain', '')
                 if not domain:
                     continue
-                if domain != self.request.get_host():
+                if domain != urlparse(self.request.get_host()).scheme:
                     other_domains.add(domain)
                     continue
             self.available_methods[factor.key_type].append(factor)


### PR DESCRIPTION
Changed request.get_host references to enable fido2 auth to run on localhost:port during dev

Regarding Issue [81](https://github.com/oliwarner/django-multifactor/issues/81)