### PR TITLE
Updated to show support for Django 5.1 and to support Django > 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ FIDO2/WebAuthn is the big-ticket item for MFA. It allows the browser to interfac
  * **NFC devices using PCSC** (Not Tested, but as supported in fido2)
 
 # Python and Django Support
-This project targets modern stacks, officially supporting Python 3.8+ and Django 3.2+.
+This project targets modern stacks, officially supporting Python 3.8+ and Django 3.2+. We advise using the latest supported combinations where possible.
 
 | **Python/Django** | **2.2** |**3.2** | **4.0** | **4.1** | **4.2** | **5.0** |
 |-------------------|---------|--------|---------|---------|---------|---------|

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ FIDO2/WebAuthn is the big-ticket item for MFA. It allows the browser to interfac
  * **NFC devices using PCSC** (Not Tested, but as supported in fido2)
 
 # Python and Django Support
-This project targets modern stacks, officially supporting Python 3.8+ and Django 3.2+. We advise using the latest supported combinations where possible.
+This project targets modern stacks, officially supporting Python 3.8+ and Django 3.2+.
 
-| **Python/Django** | **2.2** |**3.2** | **4.0** | **4.1** | **4.2** | **5.0** |
-|-------------------|---------|--------|---------|---------|---------|---------|
-| 3.8               | Y       | Y      | Y       | Y       | N/A     | N/A     |
-| 3.9               | Y       | Y      | Y       | Y       | N/A     | N/A     |
-| 3.10              | N       | Y      | Y       | Y       | N/A     | Y       |
-| 3.11              | N       | N      | N       | Y       | Y       | Y       |
-| 3.12              | N       | N      | N       | N       | Y       | Y       |
+| **Python/Django** | **2.2** |**3.2** | **4.0** | **4.1** | **4.2** | **5.0** | **5.0** |
+|-------------------|---------|--------|---------|---------|---------|---------|---------|
+| 3.8               | Y       | Y      | Y       | Y       | N/A     | N/A     | N/A     |
+| 3.9               | Y       | Y      | Y       | Y       | N/A     | N/A     | N/A     |
+| 3.10              | N       | Y      | Y       | Y       | N/A     | Y       | Y       |
+| 3.11              | N       | N      | N       | Y       | Y       | Y       | Y       |
+| 3.12              | N       | N      | N       | N       | Y       | Y       | Y       |
 
 * Python 3.11 only works with Django 4.1.3+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ include = [
 python = ">=3.7, <4.0"
 django = "> 2.2, < 5.2"
 pyotp = '^2.9'
-fido2 = '1.1.2'
+fido2 = ">1.1.2,<1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
@@ -43,7 +44,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = ">=3.7, <4.0"
-django = "> 2.2, <= 5.1"
+django = "> 2.2, < 5.2"
 pyotp = '^2.9'
 fido2 = '1.1.2'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ include = [
 python = ">=3.7, <4.0"
 django = "> 2.2, < 5.2"
 pyotp = '^2.9'
-fido2 = ">1.1.2,<1.2"
+fido2 = ">=1.1.2,<1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"


### PR DESCRIPTION
This PR includes the fixes required for #92 to show support for Django 5.1 and to allow the package to be installed on Django 5.1.* as previously it was pinned to <= 5.1.0

I published a PR for this then reverted it as I accidentally merged it in where I wanted @oliwarner to review, merge, bump the version and release a new build to pypi